### PR TITLE
Embed YouTube tutorials in How-To guides

### DIFF
--- a/assets/data/howto-data.json
+++ b/assets/data/howto-data.json
@@ -9,8 +9,9 @@
   {
     "id": "onboarding",
     "title": "How to Finish Onboarding?",
+    "videoUrl": "https://youtube.com/shorts/MC8KKMsBkOI",
     "steps": [
-      "1. Open the [GymMate Portal](https://app.gymmate.co.in/).\n\n2. Log in using your Gmail account.\n\n3. After logging in, you’ll be redirected to the Settings screen.\n\n4. Click **Select Spreadsheet** — this will open Google Drive. You’ll see a sheet named after your gym; please select it.\n\n5. Click **Save** on the Settings screen.\n\n6. Navigate to the Members screen.\n\n7. Click the **Refresh** button.\n\n8. If you see a member named “Unknown”, your setup is complete, and you’ve been successfully onboarded.\n\n\n📽️ Watch this short tutorial for guidance: [YouTube Short](https://youtube.com/shorts/5rWE82An-dg?feature=share)"
+      "1. Open the [GymMate Portal](https://app.gymmate.co.in/).\n\n2. Log in using your Gmail account.\n\n3. After logging in, you’ll be redirected to the Settings screen.\n\n4. Click **Select Spreadsheet** — this will open Google Drive. You’ll see a sheet named after your gym; please select it.\n\n5. Click **Save** on the Settings screen.\n\n6. Navigate to the Members screen.\n\n7. Click the **Refresh** button.\n\n8. If you see a member named “Unknown”, your setup is complete, and you’ve been successfully onboarded."
     ]
   },
   {

--- a/how-to/how-to.html
+++ b/how-to/how-to.html
@@ -115,6 +115,21 @@
       animation: fadeIn 0.3s ease;
     }
 
+    .video-wrapper {
+      margin: 20px 0 8px;
+      max-width: 320px;
+      aspect-ratio: 9 / 16;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    }
+
+    .video-wrapper iframe {
+      width: 100%;
+      height: 100%;
+      border: 0;
+    }
+
     @keyframes fadeIn {
       from { opacity: 0; transform: translateY(-4px); }
       to { opacity: 1; transform: translateY(0); }
@@ -138,6 +153,15 @@
     });
     
 
+    function getYoutubeEmbedUrl(videoUrl) {
+      if (!videoUrl) return "";
+      const shortsMatch = videoUrl.match(/youtube\.com\/shorts\/([A-Za-z0-9_-]{11})/);
+      const watchMatch = videoUrl.match(/[?&]v=([A-Za-z0-9_-]{11})/);
+      const directMatch = videoUrl.match(/youtu\.be\/([A-Za-z0-9_-]{11})/);
+      const videoId = shortsMatch?.[1] || watchMatch?.[1] || directMatch?.[1];
+      return videoId ? `https://www.youtube.com/embed/${videoId}` : "";
+    }
+
     async function loadHowTo() {
       try {
         const response = await fetch("../assets/data/howto-data.json");
@@ -148,6 +172,7 @@
         howTos.forEach((item) => {
           const div = document.createElement("div");
           div.className = "howto-item";
+          const embedUrl = getYoutubeEmbedUrl(item.videoUrl);
 
           div.innerHTML = `
             <div class="howto-header">
@@ -156,6 +181,16 @@
             </div>
             <div class="steps">
               ${item.steps.map(step => `<p>${marked.parse(step)}</p>`).join("")}
+              ${embedUrl ? `
+                <div class="video-wrapper">
+                  <iframe
+                    src="${embedUrl}"
+                    title="${item.title} video tutorial"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    allowfullscreen>
+                  </iframe>
+                </div>` : ""}
             </div>
           `;
 


### PR DESCRIPTION
### Motivation
- Add inline video tutorials to the how-to pages so users can watch onboarding guidance directly on the site.
- Move the tutorial link out of the step text and into structured data so videos can be rendered consistently for any guide.

### Description
- Add a `videoUrl` field to `assets/data/howto-data.json` for the `onboarding` guide and remove the inline YouTube short link from the markdown steps.
- Add `.video-wrapper` CSS and responsive iframe styling in `how-to/how-to.html` to display 9:16 video embeds with rounded corners and shadow.
- Implement `getYoutubeEmbedUrl` to parse multiple YouTube URL formats (shorts, watch, youtu.be) and produce an embed URL used to render an iframe when present.
- Inject the video iframe under the rendered steps with `loading="lazy"` and appropriate `allow` attributes while preserving existing markdown rendering via `marked`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2be8478c08320a3cda1bc9432c0bc)